### PR TITLE
PCA

### DIFF
--- a/core/src/main/scala/org/trustedanalytics/sparktk/frame/Schema.scala
+++ b/core/src/main/scala/org/trustedanalytics/sparktk/frame/Schema.scala
@@ -4,6 +4,7 @@ import java.util.{ ArrayList => JArrayList }
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
+import org.apache.commons.lang.{ StringUtils => CommonsStringUtils }
 import org.trustedanalytics.sparktk.frame.DataTypes.DataType
 import org.trustedanalytics.sparktk.frame.internal.rdd.FrameRdd
 
@@ -164,9 +165,9 @@ object Column {
  *
  * @param columns the columns in the data frame
  */
-case class FrameSchema(columns: Vector[Column] = Vector[Column]()) extends Schema {
+case class FrameSchema(columns: Seq[Column] = Vector[Column]()) extends Schema {
 
-  override def copy(columns: Vector[Column]): FrameSchema = {
+  override def copy(columns: Seq[Column]): FrameSchema = {
     new FrameSchema(columns)
   }
 
@@ -344,7 +345,7 @@ object SchemaHelper {
  */
 trait Schema {
 
-  val columns: Vector[Column]
+  val columns: Seq[Column]
 
   require(columns != null, "columns must not be null")
   require({
@@ -354,9 +355,9 @@ trait Schema {
 
   private lazy val namesToIndices: Map[String, Int] = (for ((col, i) <- columns.zipWithIndex) yield (col.name, i)).toMap
 
-  def copy(columns: Vector[Column]): Schema
+  def copy(columns: Seq[Column]): Schema
 
-  def columnNames: Vector[String] = {
+  def columnNames: Seq[String] = {
     columns.map(col => col.name)
   }
 
@@ -434,6 +435,7 @@ trait Schema {
    */
   def requireColumnsAreVectorizable(columnNames: Seq[String]): Unit = {
     require(columnNames.nonEmpty, "single vector column, or one or more numeric columns required")
+    columnNames.foreach { c => require(CommonsStringUtils.isNotEmpty(c), "data columns names cannot be empty") }
     if (columnNames.size > 1) {
       requireColumnsOfNumericPrimitives(columnNames)
     }
@@ -515,7 +517,7 @@ trait Schema {
    */
   def union(schema: Schema): Schema = {
     // check for conflicts
-    val newColumns: Vector[Column] = schema.columns.filterNot(c => {
+    val newColumns: Seq[Column] = schema.columns.filterNot(c => {
       hasColumn(c.name) && {
         require(hasColumnWithType(c.name, c.dataType), s"columns with same name ${c.name} didn't have matching types"); true
       }

--- a/core/src/main/scala/org/trustedanalytics/sparktk/frame/internal/BaseFrame.scala
+++ b/core/src/main/scala/org/trustedanalytics/sparktk/frame/internal/BaseFrame.scala
@@ -57,7 +57,7 @@ trait BaseFrame {
     SchemaValidationReturn(validatedRdd, ValidationReport(badValueCount.value))
   }
 
-  protected def init(rdd: RDD[Row], schema: Schema): Unit = {
+  private[sparktk] def init(rdd: RDD[Row], schema: Schema): Unit = {
     frameState = FrameState(rdd, schema)
   }
 

--- a/core/src/main/scala/org/trustedanalytics/sparktk/frame/internal/rdd/FrameRdd.scala
+++ b/core/src/main/scala/org/trustedanalytics/sparktk/frame/internal/rdd/FrameRdd.scala
@@ -141,7 +141,7 @@ class FrameRdd(val frameSchema: Schema, val prev: RDD[Row])
    * @param columnNames Names of the frame's column(s) whose column statistics are to be computed
    * @return MLLib's MultivariateStatisticalSummary
    */
-  def columnStatistics(columnNames: List[String]): MultivariateStatisticalSummary = {
+  def columnStatistics(columnNames: Seq[String]): MultivariateStatisticalSummary = {
     val vectorRdd = toDenseVectorRdd(columnNames)
     Statistics.colStats(vectorRdd)
   }
@@ -151,7 +151,7 @@ class FrameRdd(val frameSchema: Schema, val prev: RDD[Row])
    * @param featureColumnNames Names of the frame's column(s) to be used
    * @return RDD of (org.apache.spark.mllib)Vector
    */
-  def toMeanCenteredDenseVectorRDD(featureColumnNames: List[String]): RDD[Vector] = {
+  def toMeanCenteredDenseVectorRdd(featureColumnNames: Seq[String]): RDD[Vector] = {
     val vectorRdd = toDenseVectorRdd(featureColumnNames)
     val columnMeans: Vector = columnStatistics(featureColumnNames).mean
     vectorRdd.map(i => {
@@ -752,7 +752,7 @@ object FrameRdd {
    * Converts the schema object to a StructType for use in creating a SchemaRDD
    * @return StructType with StructFields corresponding to the columns of the schema object
    */
-  def schemaToAvroType(schema: Schema): scala.collection.immutable.Vector[(String, String)] = {
+  def schemaToAvroType(schema: Schema): Seq[(String, String)] = {
     val fields = schema.columns.map {
       column =>
         (column.name.replaceAll("\\s", ""), column.dataType match {

--- a/core/src/main/scala/org/trustedanalytics/sparktk/models/dimreduction/pca/PcaModel.scala
+++ b/core/src/main/scala/org/trustedanalytics/sparktk/models/dimreduction/pca/PcaModel.scala
@@ -1,0 +1,255 @@
+package org.trustedanalytics.sparktk.models.dimreduction.pca
+
+import org.json4s.JsonAST.JValue
+
+import org.apache.spark.SparkContext
+import org.apache.spark.mllib.linalg.{ Vector => MllibVector, Vectors => MllibVectors, Matrix => MllibMatrix, Matrices => MllibMatrices, DenseVector }
+import org.apache.spark.mllib.linalg.distributed.{ RowMatrix, IndexedRow, IndexedRowMatrix }
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+
+import org.trustedanalytics.sparktk.frame._
+import org.trustedanalytics.sparktk.frame.internal.rdd.FrameRdd
+import org.trustedanalytics.sparktk.saveload.{ TkSaveLoad, SaveLoad, TkSaveableObject }
+
+object PcaModel extends TkSaveableObject {
+
+  /**
+   * Create a new PcaModel and train it according to the given arguments
+   *
+   * @param frame The frame containing the data to train on
+   * @param columns The columns to train on
+   * @param meanCentered Option to mean center the columns
+   * @param k Principal component count. Default is the number of observation columns
+   */
+  def train(frame: Frame,
+            columns: Seq[String],
+            meanCentered: Boolean = true,
+            k: Option[Int] = None): PcaModel = {
+    require(frame != null, "frame is required")
+    require(columns != null, "data columns names cannot be null")
+    frame.schema.requireColumnsAreVectorizable(columns)
+    require(k != null)
+    if (k.isDefined) {
+      require(k.get <= columns.length, s"k=$k must be less than or equal to the number of observation columns=${columns.length}")
+      require(k.get >= 1, s"number of Eigen values to use (k=$k) must be greater than equal to 1.")
+    }
+    val trainFrameRdd = new FrameRdd(frame.schema, frame.rdd)
+
+    val train_k = k.getOrElse(columns.length)
+
+    val rowMatrix = PrincipalComponentsFunctions.toRowMatrix(trainFrameRdd, columns, meanCentered)
+    val svd = rowMatrix.computeSVD(train_k, computeU = false)
+    val columnStatistics = trainFrameRdd.columnStatistics(columns)
+
+    var singularValues = svd.s
+    while (singularValues.size < train_k) {
+      // todo: add logging for this case, where the value count is less than k (could happen for toy data --i.e. it did)
+      singularValues = new DenseVector(singularValues.toArray :+ 0.0)
+    }
+
+    PcaModel(columns, meanCentered, train_k, columnStatistics.mean, singularValues, svd.V)
+  }
+
+  def load(sc: SparkContext, path: String, formatVersion: Int, tkMetadata: JValue): Any = {
+    validateFormatVersion(formatVersion, 1)
+    val json: PcaModelJson = SaveLoad.extractFromJValue[PcaModelJson](tkMetadata)
+    json.toPcaModel
+  }
+}
+
+/**
+ * A PCA Model, holding all the important parameters
+ *
+ * @param columns sequence of observation columns of the data frame
+ * @param meanCentered Indicator whether the columns were mean centered for training
+ * @param k Principal component count
+ * @param columnMeans Means of the columns
+ * @param singularValues Singular values of the specified columns in the input frame
+ * @param rightSingularVectors Right singular vectors of the specified columns in the input frame
+ */
+case class PcaModel private[pca] (columns: Seq[String],
+                                  meanCentered: Boolean,
+                                  k: Int,
+                                  columnMeans: MllibVector,
+                                  singularValues: MllibVector,
+                                  rightSingularVectors: MllibMatrix) extends Serializable {
+  /**
+   * Saves this model to a file
+   *
+   * @param sc active SparkContext
+   * @param path save to path
+   */
+  def save(sc: SparkContext, path: String): Unit = {
+    val formatVersion: Int = 1
+    val jsonable = PcaModelJson(columns,
+      meanCentered,
+      k,
+      columnMeans.toArray,
+      singularValues.toArray,
+      rightSingularVectors.numRows,
+      rightSingularVectors.numCols,
+      rightSingularVectors.toArray)
+    TkSaveLoad.saveTk(sc, path, PcaModel.formatId, formatVersion, jsonable)
+  }
+
+  def columnMeansAsArray: Array[Double] = columnMeans.toArray
+
+  def singularValuesAsArray: Array[Double] = singularValues.toArray
+
+  def rightSingularVectorsAsArray: Array[Double] = {
+    rightSingularVectors.transpose.toArray
+  }
+
+  /**
+   *
+   * @param frame frame on which to base predictions and to which the predictions will be added
+   * @param columns the observation columns in that frame, must be equal to the number of columns this model was trained with.  Default is the same names as the train frame.
+   * @param meanCentered whether to mean center the columns. Default is true
+   * @param k the number of principal components to be computed, must be <= the k used in training.  Default is the trained k
+   * @param tSquaredIndex whether the t-square index is to be computed. Default is false
+   */
+  def predict(frame: Frame,
+              columns: Option[List[String]] = None,
+              meanCentered: Boolean = true,
+              k: Option[Int] = None,
+              tSquaredIndex: Boolean = false): Unit = {
+
+    if (meanCentered) {
+      require(this.meanCentered, "Cannot mean center the predict frame if the train frame was not mean centered.")
+    }
+    val predictColumns = columns.getOrElse(this.columns)
+    require(predictColumns.length == this.columns.length, "Number of columns for train and predict should be same")
+    val predictK = k.getOrElse(this.k)
+    require(predictK <= this.k, s"Number of components ($predictK) must be at most the number of components trained on ($this.k)")
+
+    val frameRdd = new FrameRdd(frame.schema, frame.rdd)
+    val indexedRowMatrix = PrincipalComponentsFunctions.toIndexedRowMatrix(frameRdd, predictColumns, meanCentered)
+    val principalComponents = PrincipalComponentsFunctions.computePrincipalComponents(rightSingularVectors, predictK, indexedRowMatrix)
+
+    val pcaColumns = for (i <- 1 to predictK) yield Column("p_" + i.toString, DataTypes.float64)
+    val (componentColumns, components) = tSquaredIndex match {
+      case true =>
+        val tSquareMatrix = PrincipalComponentsFunctions.computeTSquaredIndex(principalComponents, singularValues, predictK)
+        val tSquareColumn = Column("t_squared_index", DataTypes.float64)
+        (pcaColumns :+ tSquareColumn, tSquareMatrix)
+      case false => (pcaColumns, principalComponents)
+    }
+
+    val componentRows = components.rows.map(row => Row.fromSeq(row.vector.toArray.toSeq))
+    val componentFrame = new FrameRdd(FrameSchema(componentColumns), componentRows)
+    val resultFrameRdd = frameRdd.zipFrameRdd(componentFrame)
+    frame.init(resultFrameRdd.rdd, resultFrameRdd.schema)
+  }
+}
+
+object PrincipalComponentsFunctions extends Serializable {
+
+  /**
+   * Compute principal components using trained model
+   *
+   * @param eigenVectors Right singular vectors of the specified columns in the input frame
+   * @param c Number of principal components to compute
+   * @param indexedRowMatrix  Indexed row matrix with input data
+   * @return Principal components with projection of input into k dimensional space
+   */
+  def computePrincipalComponents(eigenVectors: MllibMatrix,
+                                 c: Int,
+                                 indexedRowMatrix: IndexedRowMatrix): IndexedRowMatrix = {
+    val y = indexedRowMatrix.multiply(eigenVectors)
+    val cComponentsOfY = new IndexedRowMatrix(y.rows.map(r => r.copy(vector = MllibVectors.dense(r.vector.toArray.take(c)))))
+    cComponentsOfY
+  }
+
+  /**
+   * Compute the t-squared index for an IndexedRowMatrix created from the input frame
+   * @param y IndexedRowMatrix storing the projection into k dimensional space
+   * @param E Singular Values
+   * @param k Number of dimensions
+   * @return IndexedRowMatrix with existing elements in the RDD and computed t-squared index
+   */
+  def computeTSquaredIndex(y: IndexedRowMatrix, E: MllibVector, k: Int): IndexedRowMatrix = {
+    val matrix = y.rows.map(row => {
+      val rowVectorToArray = row.vector.toArray
+      var t = 0d
+      for (i <- 0 until k) {
+        if (E(i) > 0)
+          t += ((rowVectorToArray(i) * rowVectorToArray(i)) / (E(i) * E(i)))
+      }
+      new IndexedRow(row.index, MllibVectors.dense(rowVectorToArray :+ t))
+    })
+    new IndexedRowMatrix(matrix)
+  }
+
+  /**
+   * Convert frame to distributed row matrix
+   *
+   * @param frameRdd Input frame
+   * @param columns List of columns names for creating row matrix
+   * @param meanCentered If true, mean center the columns
+   * @return Distributed row matrix
+   */
+  def toRowMatrix(frameRdd: FrameRdd, columns: Seq[String], meanCentered: Boolean): RowMatrix = {
+    val vectorRdd = toVectorRdd(frameRdd, columns, meanCentered)
+    new RowMatrix(vectorRdd)
+  }
+
+  /**
+   * Convert frame to distributed indexed row matrix
+   *
+   * @param frameRdd Input frame
+   * @param columns List of columns names for creating row matrix
+   * @param meanCentered If true, mean center the columns
+   * @return Distributed indexed row matrix
+   */
+  def toIndexedRowMatrix(frameRdd: FrameRdd, columns: Seq[String], meanCentered: Boolean): IndexedRowMatrix = {
+    val vectorRdd = toVectorRdd(frameRdd, columns, meanCentered)
+    new IndexedRowMatrix(vectorRdd.zipWithIndex().map { case (vector, index) => IndexedRow(index, vector) })
+  }
+
+  /**
+   * Convert frame to vector RDD
+   *
+   * @param frameRdd Input frame
+   * @param columns List of columns names for vector RDD
+   * @param meanCentered If true, mean center the columns
+   * @return Vector RDD
+   */
+  def toVectorRdd(frameRdd: FrameRdd, columns: Seq[String], meanCentered: Boolean): RDD[MllibVector] = {
+    if (meanCentered) {
+      frameRdd.toMeanCenteredDenseVectorRdd(columns)
+    }
+    else {
+      frameRdd.toDenseVectorRdd(columns)
+    }
+  }
+}
+
+/**
+ * PcaModel's important content represented in a case class that is easily JSON serializable
+ *
+ * @param columns sequence of observation columns of the data frame
+ * @param meanCentered Indicator whether the columns were mean centered for training
+ * @param k Principal component count
+ * @param columnMeans Means of the columns
+ * @param singularValues Singular values of the specified columns in the input frame
+ * @param rsvNumRows number of rows in the right singular vectors matrix
+ * @param rsvNumCols number of cols in the right singular vectors matrix
+ * @param rsvValues Right singular vectors of the specified columns in the input frame
+ */
+case class PcaModelJson(columns: Seq[String],
+                        meanCentered: Boolean,
+                        k: Int,
+                        columnMeans: Array[Double],
+                        singularValues: Array[Double],
+                        rsvNumRows: Int,
+                        rsvNumCols: Int,
+                        rsvValues: Array[Double]) extends Serializable {
+
+  def toPcaModel: PcaModel = {
+    val meansVector: MllibVector = MllibVectors.dense(columnMeans)
+    val sv: MllibVector = MllibVectors.dense(singularValues)
+    val rsv: MllibMatrix = MllibMatrices.dense(rsvNumRows, rsvNumCols, rsvValues)
+    PcaModel(columns, meanCentered, k, meansVector, sv, rsv)
+  }
+}

--- a/core/src/main/scala/org/trustedanalytics/sparktk/saveload/Loaders.scala
+++ b/core/src/main/scala/org/trustedanalytics/sparktk/saveload/Loaders.scala
@@ -3,6 +3,7 @@ package org.trustedanalytics.sparktk.saveload
 import org.apache.spark.SparkContext
 import org.json4s.JsonAST.JValue
 import org.trustedanalytics.sparktk.frame.Frame
+import org.trustedanalytics.sparktk.models.dimreduction.pca.PcaModel
 import org.trustedanalytics.sparktk.models.classification.naive_bayes.NaiveBayesModel
 import org.trustedanalytics.sparktk.models.classification.random_forest_classifier.RandomForestClassifierModel
 import org.trustedanalytics.sparktk.models.clustering.kmeans.KMeansModel
@@ -37,6 +38,7 @@ object Loaders {
     val entries: Seq[TkSaveableObject] = List(Frame,
       KMeansModel,
       NaiveBayesModel,
+      PcaModel,
       RandomForestClassifierModel)
     entries.map(e => e.formatId -> e.load _).toMap
   }

--- a/core/src/test/scala/org/trustedanalytics/sparktk/models/dimreduction/pca/PcaModelTest.scala
+++ b/core/src/test/scala/org/trustedanalytics/sparktk/models/dimreduction/pca/PcaModelTest.scala
@@ -1,0 +1,203 @@
+/**
+ *  Copyright (c) 2015 Intel Corporation 
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.trustedanalytics.sparktk.models.dimreduction.pca
+
+import org.apache.spark.mllib.linalg.{ Matrices, Vectors }
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.GenericRow
+import org.scalatest.Matchers
+//import org.scalatest.mock.MockitoSugar
+
+import org.scalatest.Matchers
+import org.trustedanalytics.sparktk.frame.internal.rdd.FrameRdd
+import org.trustedanalytics.sparktk.frame.{ Frame, DataTypes, Column, FrameSchema }
+
+import org.apache.spark.sql._
+import org.trustedanalytics.sparktk.testutils.TestingSparkContextWordSpec
+import org.trustedanalytics.sparktk.testutils.MatcherUtils._
+
+class PcaModelTest extends TestingSparkContextWordSpec with Matchers { //} with MockitoSugar {
+
+  val schema = FrameSchema(List(
+    Column("col_0", DataTypes.float64),
+    Column("col_1", DataTypes.float64),
+    Column("col_2", DataTypes.float64),
+    Column("col_3", DataTypes.float64),
+    Column("col_4", DataTypes.float64)
+  ))
+
+  val data: List[Row] = List(
+    new GenericRow(Array[Any](0.0, 1.0, 0.0, 7.0, 0.0)),
+    new GenericRow(Array[Any](2.0, 0.0, 3.0, 4.0, 5.0)),
+    new GenericRow(Array[Any](4.0, 0.0, 0.0, 6.0, 7.0))
+  )
+
+  val columnMeans = Vectors.dense(Array(3.0, 1.56999, 0.3))
+  val singularValues = Vectors.dense(Array(1.95285, 1.25895, 0.34988))
+  val vFactor = Matrices.dense(3, 3, Array(-0.98806, -0.14751, 0.04444, 0.152455, -0.9777, 0.14391, 0.02222, 0.14896, 0.98859))
+
+  val predictSchema = FrameSchema(List(
+    Column("col_0", DataTypes.float64),
+    Column("col_1", DataTypes.float64),
+    Column("col_2", DataTypes.float64)
+  ))
+
+  val predictInput: List[Row] = List(
+    new GenericRow(Array[Any](-0.4, 0.13001, 0.0)),
+    new GenericRow(Array[Any](3.6, 1.25, 1.0))
+  )
+
+  "PrincipalComponentsFunctions" should {
+
+    "predict principal components and t-square index without mean-centering" in {
+      val rows = sparkContext.parallelize(predictInput)
+      val frame = new Frame(rows, predictSchema)
+      val columns = List("col_0", "col_1", "col_2")
+      val modelData = PcaModel(columns, false, 3, columnMeans, singularValues, vFactor)
+
+      modelData.predict(frame, Some(columns), false, Some(3), true)
+      val resultArray = frame.rdd.map(row => {
+        for (i <- 0 until row.length) yield row.getDouble(i)
+      }).collect()
+
+      resultArray.length should equal(2)
+      resultArray(0).toArray should equalWithTolerance(Array(-0.4, 0.13001, 0.0, 0.376046, -0.188093, 0.0104783, 0.060298))
+      resultArray(1).toArray should equalWithTolerance(Array(3.6, 1.25, 1.0, -3.696964, -0.529377, 1.254782, 16.622385))
+    }
+
+    "predict principal components with mean-centering" in {
+      val rows = sparkContext.parallelize(predictInput)
+      val frame = new Frame(rows, predictSchema)
+      val columns = List("col_0", "col_1", "col_2")
+
+      val modelData = PcaModel(columns, true, 3, columnMeans, singularValues, vFactor)
+
+      modelData.predict(frame, Some(columns), true, Some(3), false)
+      val resultArray = frame.rdd.map(row => {
+        for (i <- 0 until row.length) yield row.getDouble(i)
+      }).collect()
+
+      resultArray.length should equal(2)
+      resultArray(0).toArray should equalWithTolerance(Array(-0.4, 0.13001, 0.0, 2.036505, 0.170642, -0.622152))
+      resultArray(1).toArray should equalWithTolerance(Array(3.6, 1.25, 1.0, -2.036505, -0.170642, 0.622152))
+    }
+
+    "compute the principal components" in {
+      val rows = sparkContext.parallelize(predictInput)
+      val frameRdd = new FrameRdd(predictSchema, rows)
+      val columns = List("col_0", "col_1", "col_2")
+
+      val matrix = PrincipalComponentsFunctions.toIndexedRowMatrix(frameRdd, columns, false)
+      val modelData = PcaModel(columns, true, 3, columnMeans, singularValues, vFactor)
+      val principalComponents = PrincipalComponentsFunctions.computePrincipalComponents(modelData.rightSingularVectors, 3, matrix)
+
+      principalComponents.numCols() should equal(3)
+      principalComponents.numRows() should equal(2)
+
+      val vectors = principalComponents.rows.collect()
+      vectors(0).vector.toArray should equalWithTolerance(Array(0.376046, -0.188093, 0.0104782))
+      vectors(1).vector.toArray should equalWithTolerance(Array(-3.696964, -0.529377, 1.254782))
+    }
+
+    "compute the t-squared index" in {
+      val y: List[Row] = List(
+        new GenericRow(Array[Any](0.376046, -0.188093, 0.010475)),
+        new GenericRow(Array[Any](-3.696964, -0.529377, 1.254782)),
+        new GenericRow(Array[Any](-2.806404, -1.222661, 0.607612))
+      )
+
+      val rows = sparkContext.parallelize(y)
+      val frameRdd = new FrameRdd(predictSchema, rows)
+      val columns = List("col_0", "col_1", "col_2")
+
+      val matrix = PrincipalComponentsFunctions.toIndexedRowMatrix(frameRdd, columns, false)
+      val tSquaredIndexMeanCentered = PrincipalComponentsFunctions.computeTSquaredIndex(matrix, singularValues, 3)
+
+      tSquaredIndexMeanCentered.numCols() should equal(4)
+      tSquaredIndexMeanCentered.numRows() should equal(3)
+
+      val vectors = tSquaredIndexMeanCentered.rows.collect()
+      vectors(0).vector.toArray should equalWithTolerance(Array(0.376046, -0.188093, 0.0104783, 0.060298))
+      vectors(1).vector.toArray should equalWithTolerance(Array(-3.696964, -0.529377, 1.254782, 16.622385))
+      vectors(2).vector.toArray should equalWithTolerance(Array(-2.806404, -1.222661, 0.607612, 6.024266))
+    }
+
+    "convert frame to vector RDD" in {
+      val rows = sparkContext.parallelize(data)
+      val frameRdd = new FrameRdd(schema, rows)
+      val vectors = PrincipalComponentsFunctions.toVectorRdd(frameRdd, List("col_0", "col_3"), false).collect()
+      vectors.length should equal(3)
+      vectors(0).toArray should equalWithTolerance(Array(0.0, 7.0))
+      vectors(1).toArray should equalWithTolerance(Array(2.0, 4.0))
+      vectors(2).toArray should equalWithTolerance(Array(4.0, 6.0))
+    }
+
+    "convert frame to mean-centered vector RDD" in {
+      val rows = sparkContext.parallelize(data)
+      val frameRdd = new FrameRdd(schema, rows)
+      val vectors = PrincipalComponentsFunctions.toVectorRdd(frameRdd, List("col_0", "col_3"), true).collect()
+      vectors.length should equal(3)
+      vectors(0).toArray should equalWithTolerance(Array(-2.0, 1.3333333))
+      vectors(1).toArray should equalWithTolerance(Array(0, -1.6666667))
+      vectors(2).toArray should equalWithTolerance(Array(2.0, 0.3333333))
+    }
+
+    "convert frame to row matrix" in {
+      val rows = sparkContext.parallelize(data)
+      val frameRdd = new FrameRdd(schema, rows)
+      val matrix = PrincipalComponentsFunctions.toRowMatrix(frameRdd, List("col_0", "col_3"), false)
+      matrix.numCols() should equal(2)
+      matrix.numRows() should equal(3)
+
+      val vectors = matrix.rows.collect()
+      vectors(0).toArray should equalWithTolerance(Array(0.0, 7.0))
+      vectors(1).toArray should equalWithTolerance(Array(2.0, 4.0))
+      vectors(2).toArray should equalWithTolerance(Array(4.0, 6.0))
+    }
+
+    "convert frame to indexed row matrix" in {
+      val rows = sparkContext.parallelize(data)
+      val frameRdd = new FrameRdd(schema, rows)
+      val matrix = PrincipalComponentsFunctions.toRowMatrix(frameRdd, List("col_0", "col_3"), false)
+      matrix.numCols() should equal(2)
+      matrix.numRows() should equal(3)
+
+      val vectors = matrix.rows.collect()
+      vectors(0).toArray should equalWithTolerance(Array(0.0, 7.0))
+      vectors(1).toArray should equalWithTolerance(Array(2.0, 4.0))
+      vectors(2).toArray should equalWithTolerance(Array(4.0, 6.0))
+    }
+
+    "convert frame to mean-centered indexed row matrix" in {
+      val rows = sparkContext.parallelize(data)
+      val frameRdd = new FrameRdd(schema, rows)
+
+      val matrix = PrincipalComponentsFunctions.toIndexedRowMatrix(frameRdd, List("col_0", "col_3"), true)
+      matrix.numCols() should equal(2)
+      matrix.numRows() should equal(3)
+
+      val vectors = matrix.rows.collect()
+      vectors(0).index should equal(0)
+      vectors(1).index should equal(1)
+      vectors(2).index should equal(2)
+      vectors(0).vector.toArray should equalWithTolerance(Array(-2.0, 1.3333333))
+      vectors(1).vector.toArray should equalWithTolerance(Array(0, -1.6666667))
+      vectors(2).vector.toArray should equalWithTolerance(Array(2.0, 0.3333333))
+    }
+  }
+
+}

--- a/core/src/test/scala/org/trustedanalytics/sparktk/testutils/MatcherUtils.scala
+++ b/core/src/test/scala/org/trustedanalytics/sparktk/testutils/MatcherUtils.scala
@@ -30,7 +30,7 @@ object MatcherUtils extends Matchers {
    * Array(0.12, 0.25) should  equalWithTolerance(Array(0.122, 0.254), 0.01)
    * </pre>
    */
-  def equalWithTolerance(right: Array[Double], tolerance: Double = 1E-6) =
+  def equalWithTolerance(right: Array[Double], tolerance: Double = 1E-5) =
     Matcher { (left: Array[Double]) =>
       MatchResult(
         (left zip right) forall { case (a, b) => a === (b +- tolerance) },

--- a/integration-tests/tests/setup.py
+++ b/integration-tests/tests/setup.py
@@ -22,6 +22,7 @@ def tc(request):
         if global_tc is None:
             from sparktk import TkContext
             from sparktk import create_sc
+            from sparktk.tests import utils
             #from sparktk.loggers import loggers
             #loggers.set("d", "sparktk.sparkconf")
             sc = create_sc(master='local[2]',
@@ -29,6 +30,7 @@ def tc(request):
                            extra_conf={"spark.hadoop.fs.default.name": "file:///"})
             request.addfinalizer(lambda: sc.stop())
             global_tc = TkContext(sc)
+            global_tc.testing = utils
     return global_tc
 
 

--- a/integration-tests/tests/test_gendoct.py
+++ b/integration-tests/tests/test_gendoct.py
@@ -60,14 +60,25 @@ end
 """
 
         expected_doctest = """
+
 >>> import trustedanalytics as ta  # invisible set up code
 >>> ta.connect()
 -etc-
 
+
 Blah Blah
+
 More mysteries
 <and>
 Disguises
+
+
+
+
+
+
+
+
 
 end
 """

--- a/python/sparktk/doc/builddoc.sh
+++ b/python/sparktk/doc/builddoc.sh
@@ -6,6 +6,7 @@
 NAME="[`basename $0`]"
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 echo "$NAME DIR=$DIR"
+cd $DIR
 
 SPARKTK_DIR="$(dirname "$DIR")"
 

--- a/python/sparktk/doc/docutils.py
+++ b/python/sparktk/doc/docutils.py
@@ -110,10 +110,12 @@ class DocExamplesPreprocessor(object):
             # process for human-consumable documentation
             self.replacements = self.doc_replacements
             self.is_state_keep = self._is_hide_state_keep
+            self._disappear  = ''   # in documentation, we need complete disappearance
         elif mode == 'doctest':
             # process for doctest execution
             self.replacements = self.doctest_replacements
             self.is_state_keep = self._is_skip_state_keep
+            self._disappear = '\n'  # disappear means blank line for doctests, to preserve line numbers for error report
         else:
             raise DocExamplesException('Invalid mode "%s" given to %s.  Must be in %s' %
                                        (mode, self.__class__, ", ".join(['doc', 'doctest'])))
@@ -153,7 +155,7 @@ class DocExamplesPreprocessor(object):
             stripped = DocExamplesPreprocessor._strip_markdown_comment(stripped)
             if stripped[0] == '<':
                 if self._process_if_tag_pair_tag(stripped):
-                    return ''  # return empty string, as tag-pari markup should disappear
+                    return self._disappear  # tag-pair markup should disappear appropriately
 
                 # check for keyword replacement
                 for keyword, replacement in self.replacements:
@@ -161,7 +163,7 @@ class DocExamplesPreprocessor(object):
                         line = line.replace(keyword, replacement, 1)
                         break
 
-        return line if self.is_state_keep() else ''
+        return line if self.is_state_keep() else self._disappear
 
     def _process_if_tag_pair_tag(self, stripped):
         """determines if the stripped line is a tag pair start or stop, advances fsms accordingly"""

--- a/python/sparktk/frame/constructors/create.py
+++ b/python/sparktk/frame/constructors/create.py
@@ -98,5 +98,7 @@ def create(data, schema=None, validate_schema=False, tc=implicit):
     schema, and further frame operations may fail due to the data type discrepancy.
 
     """
+    if tc is implicit:
+        implicit.error('tc')    
     from sparktk.frame.frame import Frame
     return Frame(tc, data, schema, validate_schema)

--- a/python/sparktk/models/classification/pca.py
+++ b/python/sparktk/models/classification/pca.py
@@ -1,1 +1,0 @@
-print "** Loading pca.py"

--- a/python/sparktk/models/clustering/kmeans.py
+++ b/python/sparktk/models/clustering/kmeans.py
@@ -7,7 +7,6 @@ def train(frame, columns, k=2, scalings=None, max_iter=20, epsilon=1e-4, seed=No
     """
     Creates a KMeansModel by training on the given frame
 
-    :param tc: TkContext
     :param frame: frame of training data
     :param columns: names of columns containing the observations for training
     :param k: number of clusters

--- a/python/sparktk/models/dimreduction/__init__.py
+++ b/python/sparktk/models/dimreduction/__init__.py
@@ -1,0 +1,1 @@
+from sparktk.loggers import log_load; log_load(__name__); del log_load

--- a/python/sparktk/models/dimreduction/pca.py
+++ b/python/sparktk/models/dimreduction/pca.py
@@ -1,0 +1,180 @@
+from sparktk.loggers import log_load; log_load(__name__); del log_load
+
+from sparktk.propobj import PropertiesObject
+
+
+def train(frame, columns, mean_centered=True, k=None):
+    """
+    Creates a PcaModel by training on the given frame
+
+    Parameters
+    ----------
+
+    :param frame: (Frame) A frame of training data.
+    :param columns: (str or list[str]) Names of columns containing the observations for training.
+    :param mean_centered: (bool) Whether to mean center the columns.
+    :param k: (int) Principal component count. Default is the number of observation columns.
+    :return: (PcaModel) The trained PCA model
+    """
+    tc = frame._tc
+    _scala_obj = get_scala_obj(tc)
+    scala_columns = tc.jutils.convert.to_scala_vector_string(columns)
+    if not isinstance(mean_centered, bool):
+        raise ValueError("mean_centered must be a bool, received %s" % type(mean_centered))
+    scala_k = tc.jutils.convert.to_scala_option(k)
+    scala_model = _scala_obj.train(frame._scala, scala_columns, mean_centered, scala_k)
+    return PcaModel(tc, scala_model)
+
+
+def get_scala_obj(tc):
+    """Gets reference to the scala object"""
+    return tc.sc._jvm.org.trustedanalytics.sparktk.models.dimreduction.pca.PcaModel
+
+
+class PcaModel(PropertiesObject):
+    """
+    Princiapl Component Analysis Model
+
+    Example
+    -------
+
+        >>> frame = tc.frame.create([[2.6,1.7,0.3,1.5,0.8,0.7],
+        ...                          [3.3,1.8,0.4,0.7,0.9,0.8],
+        ...                          [3.5,1.7,0.3,1.7,0.6,0.4],
+        ...                          [3.7,1.0,0.5,1.2,0.6,0.3],
+        ...                          [1.5,1.2,0.5,1.4,0.6,0.4]],
+        ...                         [("1", float), ("2", float), ("3", float), ("4", float), ("5", float), ("6", float)])
+        -etc-
+
+
+
+        >>> frame.inspect()
+        [#]  1    2    3    4    5    6
+        =================================
+        [0]  2.6  1.7  0.3  1.5  0.8  0.7
+        [1]  3.3  1.8  0.4  0.7  0.9  0.8
+        [2]  3.5  1.7  0.3  1.7  0.6  0.4
+        [3]  3.7  1.0  0.5  1.2  0.6  0.3
+        [4]  1.5  1.2  0.5  1.4  0.6  0.4
+
+        >>> model = tc.models.dimreduction.pca.train(frame, ['1','2','3','4','5','6'], mean_centered=True, k=4)
+
+        >>> model.columns
+        [u'1', u'2', u'3', u'4', u'5', u'6']
+
+        <skip>
+        >>> model.column_means
+        [2.92, 1.48, 0.4, 1.3, 0.7, 0.52]
+        </skip>
+
+        <hide>
+        >>> expected_means =  [2.92, 1.48, 0.4, 1.3, 0.7, 0.52]
+
+        >>> tc.testing.compare_floats(expected_means, model.column_means, precision=0.001)
+
+        </hide>
+
+        <skip>
+        >>> model.singular_values
+        [1.804817009663242, 0.8835344148403884, 0.7367461843294286, 0.15234027471064396]
+        </skip>
+
+        <hide>
+        >>> tc.testing.compare_floats([1.804817009663242, 0.8835344148403884, 0.7367461843294286, 0.15234027471064396], model.singular_values, 0.00000000001)
+
+        </hide>
+
+        <skip>
+        >>> model.right_singular_vectors
+        [[-0.9906468642089336, 0.11801374544146298, 0.02564701035332026, 0.04852509627553534], [-0.07735139793384983, -0.6023104604841426, 0.6064054412059492, -0.4961696216881456], [0.028850639537397756, 0.07268697636708586, -0.24463936400591005, -0.17103491337994484], [0.10576208410025367, 0.5480329468552814, 0.7523059089872701, 0.2866144016081254], [-0.024072151446194616, -0.30472267167437644, -0.011259366445851784, 0.48934541040601887], [-0.00617295395184184, -0.47414707747028795, 0.0753345822621543, 0.6329307498105843]]
+
+        </skip>
+
+        <hide>
+        >>> expected = [[-0.9906468642089336, 0.11801374544146298, 0.02564701035332026, 0.04852509627553534], [-0.07735139793384983, -0.6023104604841426, 0.6064054412059492, -0.4961696216881456], [0.028850639537397756, 0.07268697636708586, -0.24463936400591005, -0.17103491337994484], [0.10576208410025367, 0.5480329468552814, 0.7523059089872701, 0.2866144016081254], [-0.024072151446194616, -0.30472267167437644, -0.011259366445851784, 0.48934541040601887], [-0.00617295395184184, -0.47414707747028795, 0.0753345822621543, 0.6329307498105843]]
+
+        >>> got = model.right_singular_vectors
+
+        >>> if len(expected) != len(got):
+        ...     raise RuntimeError("Mismatched lengths for right_singular_vectors, expected %s != got %s" % (len(expected), len(got)))
+
+        >>> for i in xrange(len(got)):
+        ...     tc.testing.compare_floats(expected[i], got[i], 0.000001)
+
+        </hide>
+
+        >>> model.predict(frame, mean_centered=True, t_squared_index=True, columns=['1','2','3','4','5','6'], k=3)
+        -etc-
+
+        >>> frame.inspect()
+        [#]  1    2    3    4    5    6    p_1              p_2
+        ===================================================================
+        [0]  2.6  1.7  0.3  1.5  0.8  0.7   0.314738695012  -0.183753549226
+        [1]  3.3  1.8  0.4  0.7  0.9  0.8  -0.471198363594  -0.670419608227
+        [2]  3.5  1.7  0.3  1.7  0.6  0.4  -0.549024749481   0.235254068619
+        [3]  3.7  1.0  0.5  1.2  0.6  0.3  -0.739501762517   0.468409769639
+        [4]  1.5  1.2  0.5  1.4  0.6  0.4    1.44498618058   0.150509319195
+        <BLANKLINE>
+        [#]  p_3              t_squared_index
+        =====================================
+        [0]   0.312561560113   0.253649649849
+        [1]  -0.228746130528   0.740327252782
+        [2]   0.465756549839   0.563086507007
+        [3]  -0.386212142456   0.723748467549
+        [4]  -0.163359836968   0.719188122813
+
+        >>> model.save('sandbox/pca1')
+
+        >>> model2 = tc.load('sandbox/pca1')
+
+        >>> model2.k
+        4
+
+    """
+
+    def __init__(self, tc, scala_model):
+        self._tc = tc
+        tc.jutils.validate_is_jvm_instance_of(scala_model, get_scala_obj(tc))
+        self._scala = scala_model
+
+    @staticmethod
+    def load(tc, scala_model):
+        return PcaModel(tc, scala_model)
+
+    @property
+    def columns(self):
+        return list(self._tc.jutils.convert.from_scala_seq(self._scala.columns()))
+
+    @property
+    def mean_centered(self):
+        return self._scala.meanCentered()
+
+    @property
+    def k(self):
+        return self._scala.k()
+
+    @property
+    def column_means(self):
+        return list(self._scala.columnMeansAsArray())
+
+    @property
+    def singular_values(self):
+        return list(self._scala.singularValuesAsArray())
+
+    @property
+    def right_singular_vectors(self):
+        x = list(self._scala.rightSingularVectorsAsArray())
+        return [x[i:i+self.k] for i in xrange(0,len(x),self.k)]
+
+    def predict(self, frame, columns=None, mean_centered=None, k=None, t_squared_index=False):
+        """Adds columns to the given frame which are the principal compenent predictions"""
+        if mean_centered is None:
+            mean_centered = self.mean_centered
+        self._scala.predict(frame._scala,
+                            self._tc.jutils.convert.to_scala_option_list_string(columns),
+                            mean_centered,
+                            self._tc.jutils.convert.to_scala_option(k),
+                            t_squared_index)
+
+    def save(self, path):
+        self._scala.save(self._tc._scala_sc, path)

--- a/python/sparktk/tests/utils.py
+++ b/python/sparktk/tests/utils.py
@@ -1,0 +1,11 @@
+
+def compare_floats(a, b, precision=0.001):
+    if len(a) != len(b):
+        raise RuntimeError("sequences of floats have different lengths (%s != %s)\n  a: %s\n  b: %s" % (len(a), len(b), a, b))
+    for i in xrange(len(a)):
+        if abs(a[i] - b[i]) > precision:
+            raise RuntimeError("Difference between floats %s and %s is greater than allowed precision %s\n  a: %s\n  b: %s" % (a[i], b[i], precision, a, b))
+
+
+def test_x():
+    raise Exception("Hey test runner, don't call me")


### PR DESCRIPTION
Squashed commit of the following:

commit 3954477f07b4b70a0a8fea309fdff6e33ed099d0
Author: Briton Barker briton.barker@intel.com
Date:   Mon Jun 20 19:49:13 2016 -0700

```
pca scala unit tests, moved to dimreduction
```

commit 30b6b14ad26dbc8d3114568223be2c2d7985b7e5
Author: Briton Barker briton.barker@intel.com
Date:   Mon Jun 20 17:23:53 2016 -0700

```
pca cleanup
```

commit d668d893699a35bc27c6189cea387909ceb20bfe
Merge: b5e0fe7 15bd472
Author: Briton Barker briton.barker@intel.com
Date:   Fri Jun 17 18:19:37 2016 -0700

```
Merge branch 'master' of https://github.com/trustedanalytics/spark-tk into DPNG-7923

Conflicts:
    core/src/main/scala/org/trustedanalytics/sparktk/frame/internal/BaseFrame.scala
    core/src/main/scala/org/trustedanalytics/sparktk/saveload/Loaders.scala
    python/sparktk/frame/constructors/create.py
```

commit b5e0fe75706a6107f21ae4af42bd4762e391e426
Author: Briton Barker briton.barker@intel.com
Date:   Fri Jun 17 18:16:39 2016 -0700

```
checkpoint pca
```

commit 05364e2afd3c6fe01058d56151b8d63699a7fec1
Merge: 024c8fd e7e8a73
Author: Briton Barker briton.barker@intel.com
Date:   Wed Jun 15 17:25:32 2016 -0700

```
Merge branch 'master' of https://github.com/trustedanalytics/spark-tk into DPNG-7923

Conflicts:
    core/src/main/scala/org/trustedanalytics/sparktk/saveload/Loaders.scala
```

commit 024c8fd9530396a0e97cc7a74f570a9d1036e527
Author: Briton Barker briton.barker@intel.com
Date:   Mon Jun 13 11:26:54 2016 -0700

```
pca checkpoint
```
