### PR TITLE
DPNG-9030 Spark-tk renaming columns

### DIFF
--- a/integration-tests/tests/test_frame_rename_columns.py
+++ b/integration-tests/tests/test_frame_rename_columns.py
@@ -1,0 +1,82 @@
+from setup import tc
+
+data = [["Bob", 30, 8], ["Jim", 45, 9.5], ["Sue", 25, 7], ["George", 15, 6], ["Jennifer", 18, 8.5]]
+
+def test_rename_single_column(tc):
+    schema = [("name", str), ("age", int), ("shoe_size", float)]
+    new_column_name = {"name": "nick"}
+    frame = tc.frame.create(data, schema)
+    frame.rename_columns(new_column_name)
+    assert(frame.schema == [("nick", str), ("age", int), ("shoe_size", float)])
+
+def test_rename_single_column_to_existing_name(tc):
+    schema = [("name", str), ("age", int), ("shoe_size", float)]
+    new_column_name = {"name": "shoe_size"}
+    frame = tc.frame.create(data, schema)
+    try:
+        frame.rename_columns(new_column_name)
+        raise RuntimeError("Expected ValueError when passing column name which exists")
+    except ValueError:
+        pass
+
+def test_rename_multiple_columns(tc):
+    schema = [("name", str), ("age", int), ("shoe_size", float)]
+    new_column_name = {"name": "Name", "age": "Age"}
+    frame = tc.frame.create(data, schema)
+    frame.rename_columns(new_column_name)
+    assert(frame.schema == [("Name", str), ("Age", int), ("shoe_size", float)])
+
+def test_rename_multiple_columns_when_first_exists(tc):
+    schema = [("name", str), ("age", int), ("shoe_size", float)]
+    frame = tc.frame.create(data, schema)
+    new_column_name = {"name": "shoe_size", "age": "Age"}
+    try:
+        frame.rename_columns(new_column_name)
+        raise RuntimeError("Expected ValueError when passing multiple columns names and one of them exists")
+    except ValueError:
+        pass
+
+def test_rename_multiple_columns_when_second_exists(tc):
+    schema = [("name", str), ("age", int), ("shoe_size", float)]
+    new_column_name = {"name": "Name", "age": "shoe_size"}
+    frame = tc.frame.create(data, schema)
+    try:
+        frame.rename_columns(new_column_name)
+        raise RuntimeError("Expected ValueError when passing multiple columns names and one of them exists")
+    except ValueError:
+        pass
+
+def test_rename_multiple_columns_when_first_is_new_and_second_is_old(tc):
+    schema = [("name", str), ("age", int), ("shoe_size", float)]
+    new_column_name = {"name": "Name", "age": "name"}
+    frame = tc.frame.create(data, schema)
+    frame.rename_columns(new_column_name)
+    assert(frame.schema == [("Name", str), ("name", int), ("shoe_size", float)])
+
+def test_rename_multiple_columns_changing(tc):
+    schema = [("name", str), ("age", int), ("shoe_size", float)]
+    new_column_name = {"name": "age", "age": "name"}
+    frame = tc.frame.create(data, schema)
+    frame.rename_columns(new_column_name)
+    assert(frame.schema == [("age", str), ("name", int), ("shoe_size", float)])
+
+
+def test_rename_multiple_not_unique_names(tc):
+    schema = [("name", str), ("age", int), ("shoe_size", float)]
+    new_column_name = {"name": "not_unique", "age": "not_unique"}
+    frame = tc.frame.create(data, schema)
+    try:
+        frame.rename_columns(new_column_name)
+        raise RuntimeError("Expected ValueError when passing duplicated multiple columns names")
+    except ValueError:
+        pass
+
+def test_rename_multiple_unique_and_not_unique_names(tc):
+    schema = [("name", str), ("age", int), ("shoe_size", float)]
+    new_column_name = {"name": "unique", "age": "not_unique", "shoe_size": "not_unique"}
+    frame = tc.frame.create(data, schema)
+    try:
+        frame.rename_columns(new_column_name)
+        raise RuntimeError("Expected ValueError when passing duplicated multiple columns names and one of them is unique")
+    except ValueError:
+        pass


### PR DESCRIPTION
Added test for renaming columns.

Now, the rename columns validate the new column name.
1) renaming a column to an existing column name is not allowed when it is single renaming
2) Renaming multiple columns to the same name in a single operation is not allowed
3) Column name reorder is possible ( when we have A and B column, we can in single operation do A->B and B->A)
