### PR TITLE
Modify frame.create to only accept list of row data or an RDD

### DIFF
--- a/integration-tests/tests/test_frame_create.py
+++ b/integration-tests/tests/test_frame_create.py
@@ -149,3 +149,56 @@ def test_frame_upload_raw_list_data(tc):
             assert(len(data[r]) == len(row))
             for c, column in enumerate(row):
                 assert(data[r][c] == column)
+
+def test_create_empty_frame(tc):
+    """
+    Tests creating an empty frame.
+    """
+    frame = tc.frame.create(None)
+    assert(frame.row_count == 0)
+    assert(len(frame.schema) == 0)
+    frame = tc.frame.create([])
+    assert(frame.row_count == 0)
+    assert(len(frame.schema) == 0)
+
+def test_invalid_frame_data_source(tc):
+    """
+    Tests creating a frame with an invalid data source (not a list of data or RDD)
+    """
+    # create a valid frame to test as a data source
+    frame = tc.frame.create([[1, "a"],[2, "b"]])
+    assert(frame.row_count == 2)
+    assert(frame._is_python)
+
+    try:
+        # creating a frame from a python frame should not be allowed
+        tc.frame.create(frame)
+        raise RuntimeError("Expected an error when trying to create a frame from a python frame.")
+    except TypeError as e:
+        assert("Invalid data source" in e.message)
+
+    frame._scala
+    assert(frame._is_scala)
+
+    try:
+        # creating a frame from a scala frame should not be allowed
+        tc.frame.create(frame)
+        raise RuntimeError("Expected an error when trying to create a frame from a scala frame.")
+    except TypeError as e:
+        assert("Invalid data source" in e.message)
+
+    try:
+        # creating a frame from an integer is not allowed
+        tc.frame.create(1)
+        raise RuntimeError("Expected an error when trying to create a frame from an int.")
+    except TypeError as e:
+        assert("Invalid data source" in e.message)
+
+    try:
+        # if creating a frame from a list, it should be a 2-dimensional list
+        tc.frame.create([[1,2,3], 4, [5,6,7]])
+        raise RuntimeError("Expected an error when trying to create with an invalid list.")
+    except TypeError as e:
+        assert("Invalid data source" in e.message)
+
+

--- a/python/sparktk/frame/constructors/create.py
+++ b/python/sparktk/frame/constructors/create.py
@@ -9,16 +9,17 @@ def create(data, schema=None, validate_schema=False, tc=implicit):
     not match the schema's data type, it attempts to cast the data to the proper data type.  When the data is unable
     to be casted to the schema's data type, the item will be missing (None) in the frame.
 
-    :param data: Data source
-    :param schema: Optionally specify a schema (list of tuples of string column names and data type), column names
-                   (list of strings, and the column data types will be inferred) or None (column data types will be
-                   inferred and column names will be numbered like C0, C1, C2, etc).
-    :param validate_schema: When True, all data is is checked to ensure that it matches the schema.  If the data does
-                            not match the schema's data type, it attempts to cast the data to the proper data type.
-                            When the data is unable to be casted to the schema's data type, a ValueError is raised.
-                            Defaults to False.
+    :param data: (List of row data or RDD) Data source
+    :param schema: (Optional(list[tuple(str, type)] or list[str])] Optionally specify a schema (list of tuples of
+                   string column names and data type), column names (list of strings, and the column data types will
+                   be inferred) or None (column data types will be inferred and column names will be numbered like C0,
+                   C1, C2, etc).
+    :param validate_schema: (Optional(bool)) When True, all data is is checked to ensure that it matches the schema.
+                            If the data does not match the schema's data type, it attempts to cast the data to the
+                            proper data type.  When the data is unable to be casted to the schema's data type, a
+                            ValueError is raised. Defaults to False.
     :param tc: TkContext
-    :return: Frame loaded with the specified data
+    :return: (Frame) Frame loaded with the specified data
 
 
     Examples
@@ -99,6 +100,11 @@ def create(data, schema=None, validate_schema=False, tc=implicit):
 
     """
     if tc is implicit:
-        implicit.error('tc')    
+        implicit.error('tc')
+    if data is None:
+        data = []
+    from pyspark.rdd import RDD
+    if not isinstance(data, list) and not isinstance(data, RDD) and not tc._jutils.is_jvm_instance_of(data, tc.sc._jvm.org.apache.spark.rdd.RDD):
+        raise TypeError("Invalid data source. The data parameter must be a 2-dimensional list (list of row data) or an RDD")
     from sparktk.frame.frame import Frame
     return Frame(tc, data, schema, validate_schema)

--- a/python/sparktk/frame/constructors/create.py
+++ b/python/sparktk/frame/constructors/create.py
@@ -105,6 +105,6 @@ def create(data, schema=None, validate_schema=False, tc=implicit):
     if data is None:
         data = []
     if not isinstance(data, list) and not isinstance(data, RDD) and not tc._jutils.is_jvm_instance_of(data, tc.sc._jvm.org.apache.spark.rdd.RDD):
-        raise TypeError("Invalid data source. The data parameter must be a 2-dimensional list (list of row data) or an RDD")
+        raise TypeError("Invalid data source. Expected the data parameter to be a 2-dimensional list (list of row data) or an RDD, but received: %s" % type(data))
     from sparktk.frame.frame import Frame
     return Frame(tc, data, schema, validate_schema)

--- a/python/sparktk/frame/constructors/create.py
+++ b/python/sparktk/frame/constructors/create.py
@@ -1,4 +1,5 @@
 from sparktk.lazyloader import implicit
+from pyspark.rdd import RDD
 
 def create(data, schema=None, validate_schema=False, tc=implicit):
     """
@@ -103,7 +104,6 @@ def create(data, schema=None, validate_schema=False, tc=implicit):
         implicit.error('tc')
     if data is None:
         data = []
-    from pyspark.rdd import RDD
     if not isinstance(data, list) and not isinstance(data, RDD) and not tc._jutils.is_jvm_instance_of(data, tc.sc._jvm.org.apache.spark.rdd.RDD):
         raise TypeError("Invalid data source. The data parameter must be a 2-dimensional list (list of row data) or an RDD")
     from sparktk.frame.frame import Frame

--- a/python/sparktk/frame/constructors/import_hbase.py
+++ b/python/sparktk/frame/constructors/import_hbase.py
@@ -6,11 +6,12 @@ def import_hbase(table_name, schema, start_tag=None, end_tag=None, tc=implicit):
     """
     Import data from hbase table into frame
 
-    :param table_name: hbase table name
-    :param schema: hbase schema as a List of List(string) (columnFamily, columnName, dataType for cell value)
-    :param start_tag: optional start tag for filtering
-    :param end_tag: optional end tag for filtering
-    :return: frame with data from hbase table
+    :param table_name: (str) hbase table name
+    :param schema: (list[list[str, str, type]]) hbase schema as a List of List(string) (columnFamily, columnName,
+                   dataType for cell value)
+    :param start_tag: (Optional(str)) optional start tag for filtering
+    :param end_tag: (Optional(str)) optional end tag for filtering
+    :return: (Frame) frame with data from hbase table
 
     Example
     ---------

--- a/python/sparktk/frame/constructors/import_jdbc.py
+++ b/python/sparktk/frame/constructors/import_jdbc.py
@@ -9,9 +9,9 @@ def import_jdbc(connection_url, table_name, tc=implicit):
     Parameters
     ----------
 
-    :param connection_url: JDBC connection url to database server
-    :param table_name: JDBC table name
-    :return: returns frame with jdbc table data
+    :param connection_url: (str) JDBC connection url to database server
+    :param table_name: (str) JDBC table name
+    :return: (Frame) returns frame with jdbc table data
 
     Examples
     --------

--- a/python/sparktk/frame/frame.py
+++ b/python/sparktk/frame/frame.py
@@ -26,6 +26,9 @@ class Frame(object):
             self._frame = self.create_scala_frame(tc.sc, source, scala_schema)
         else:
             if not isinstance(source, RDD):
+                if not isinstance(source, list) or (len(source) > 0 and any(not isinstance(row, list) for row in source)):
+                    raise TypeError("Invalid data source.  The data parameter must be a 2-dimensional list (list of row data) or an RDD.")
+
                 inferred_schema = False
                 if isinstance(schema, list):
                     if all(isinstance(item, basestring) for item in schema):

--- a/python/sparktk/frame/ops/correlation_matrix.py
+++ b/python/sparktk/frame/ops/correlation_matrix.py
@@ -55,6 +55,6 @@ def correlation_matrix(self, data_column_names):
         [4]             0.0             0.0              0.0              0.0  1.0
 
     """
-
-    return self._tc.frame.create(
-           self._scala.correlationMatrix(self._tc.jutils.convert.to_scala_list_string(data_column_names)))
+    from sparktk.frame.frame import Frame
+    return Frame(self._tc,
+                 self._scala.correlationMatrix(self._tc.jutils.convert.to_scala_list_string(data_column_names)))

--- a/python/sparktk/frame/ops/covariance_matrix.py
+++ b/python/sparktk/frame/ops/covariance_matrix.py
@@ -53,5 +53,6 @@ def covariance_matrix(self, data_column_names):
         [4]    0.0   0.0   0.0   0.0  0.0
 
     """
-    return self._tc.frame.create(
-        self._scala.covarianceMatrix(self._tc.jutils.convert.to_scala_list_string(data_column_names)))
+    from sparktk.frame.frame import Frame
+    return Frame(self._tc,
+                 self._scala.covarianceMatrix(self._tc.jutils.convert.to_scala_list_string(data_column_names)))

--- a/python/sparktk/frame/ops/ecdf.py
+++ b/python/sparktk/frame/ops/ecdf.py
@@ -47,4 +47,5 @@ def ecdf(self, column):
         [4]        4           1.0
 
     """
-    return self._tc.frame.create(self._scala.ecdf(column))
+    from sparktk.frame.frame import Frame
+    return Frame(self._tc, self._scala.ecdf(column))

--- a/python/sparktk/frame/ops/group_by.py
+++ b/python/sparktk/frame/ops/group_by.py
@@ -217,6 +217,6 @@ def group_by(self, group_by_columns, *aggregations):
     scala_group_by_aggregation_args = []
     for item in aggregation_list:
         scala_group_by_aggregation_args.append(self._tc.jutils.convert.to_scala_group_by_aggregation_args(item))
-
-    return self._tc.frame.create(self._scala.groupBy(self._tc.jutils.convert.to_scala_list_string(group_by_columns),
-                        self._tc.jutils.convert.to_scala_list(scala_group_by_aggregation_args)))
+    from sparktk.frame.frame import Frame
+    return Frame(self._tc, self._scala.groupBy(self._tc.jutils.convert.to_scala_list_string(group_by_columns),
+                                               self._tc.jutils.convert.to_scala_list(scala_group_by_aggregation_args)))

--- a/python/sparktk/frame/ops/join_inner.py
+++ b/python/sparktk/frame/ops/join_inner.py
@@ -211,8 +211,9 @@ def join_inner(self,
     if len(left_on) != len(right_on):
         raise ValueError("Please provide equal number of join columns")
 
-    return self._tc.frame.create(self._scala.joinInner(right._scala,
-                                              self._tc.jutils.convert.to_scala_list_string(left_on),
-                                              self._tc.jutils.convert.to_scala_option(
-                                                      self._tc.jutils.convert.to_scala_list_string(right_on)),
-                                              self._tc.jutils.convert.to_scala_option(use_broadcast)))
+    from sparktk.frame.frame import Frame
+    return Frame(self._tc, self._scala.joinInner(right._scala,
+                                                 self._tc.jutils.convert.to_scala_list_string(left_on),
+                                                 self._tc.jutils.convert.to_scala_option(
+                                                     self._tc.jutils.convert.to_scala_list_string(right_on)),
+                                                 self._tc.jutils.convert.to_scala_option(use_broadcast)))

--- a/python/sparktk/frame/ops/join_left.py
+++ b/python/sparktk/frame/ops/join_left.py
@@ -191,8 +191,9 @@ def join_left(self,
     if len(left_on) != len(right_on):
         raise ValueError("Please provide equal number of join columns")
 
-    return self._tc.frame.create(self._scala.joinLeft(right._scala,
-                                                  self._tc.jutils.convert.to_scala_list_string(left_on),
-                                                  self._tc.jutils.convert.to_scala_option(
-                                                          self._tc.jutils.convert.to_scala_list_string(right_on)),
-                                                  use_broadcast_right))
+    from sparktk.frame.frame import Frame
+    return Frame(self._tc, self._scala.joinLeft(right._scala,
+                                                self._tc.jutils.convert.to_scala_list_string(left_on),
+                                                self._tc.jutils.convert.to_scala_option(
+                                                    self._tc.jutils.convert.to_scala_list_string(right_on)),
+                                                use_broadcast_right))

--- a/python/sparktk/frame/ops/join_outer.py
+++ b/python/sparktk/frame/ops/join_outer.py
@@ -162,7 +162,8 @@ def join_outer(self,
     if len(left_on) != len(right_on):
         raise ValueError("Please provide equal number of join columns")
 
-    return self._tc.frame.create(self._scala.joinOuter(right._scala,
-                                                   self._tc.jutils.convert.to_scala_list_string(left_on),
-                                                   self._tc.jutils.convert.to_scala_option(
-                                                           self._tc.jutils.convert.to_scala_list_string(right_on))))
+    from sparktk.frame.frame import Frame
+    return Frame(self._tc, self._scala.joinOuter(right._scala,
+                                                 self._tc.jutils.convert.to_scala_list_string(left_on),
+                                                 self._tc.jutils.convert.to_scala_option(
+                                                     self._tc.jutils.convert.to_scala_list_string(right_on))))

--- a/python/sparktk/frame/ops/join_right.py
+++ b/python/sparktk/frame/ops/join_right.py
@@ -186,8 +186,9 @@ def join_right(self,
     if len(left_on) != len(right_on):
         raise ValueError("Please provide equal number of join columns")
 
-    return self._tc.frame.create(self._scala.joinRight(right._scala,
-                                                  self._tc.jutils.convert.to_scala_list_string(left_on),
-                                                  self._tc.jutils.convert.to_scala_option(
-                                                          self._tc.jutils.convert.to_scala_list_string(right_on)),
-                                                  use_broadcast_left))
+    from sparktk.frame.frame import Frame
+    return Frame(self._tc, self._scala.joinRight(right._scala,
+                                                 self._tc.jutils.convert.to_scala_list_string(left_on),
+                                                 self._tc.jutils.convert.to_scala_option(
+                                                     self._tc.jutils.convert.to_scala_list_string(right_on)),
+                                                 use_broadcast_left))

--- a/python/sparktk/frame/ops/power_iteration_clustering.py
+++ b/python/sparktk/frame/ops/power_iteration_clustering.py
@@ -74,5 +74,6 @@ def power_iteration_clustering(self, source_column, destination_column, similari
                                                   initialization_mode)
     k_val = result.k()
     cluster_sizes = self._tc.jutils.convert.scala_map_to_python(result.clusterSizes())
-    py_frame = self._tc.frame.create(result.clusterMapFrame())
+    from sparktk.frame.frame import Frame
+    py_frame = Frame(self._tc, result.clusterMapFrame())
     return PicResult(frame=py_frame, k=k_val, cluster_sizes=cluster_sizes)

--- a/python/sparktk/frame/ops/quantiles.py
+++ b/python/sparktk/frame/ops/quantiles.py
@@ -57,5 +57,5 @@ def quantiles(self, column_name, quantiles):
        [2]      100.0                           660.0
 
     """
-
-    return self._tc.frame.create(self._scala.quantiles(column_name, self._tc.jutils.convert.to_scala_list_double(quantiles)))
+    from sparktk.frame.frame import Frame
+    return Frame(self._tc, self._scala.quantiles(column_name, self._tc.jutils.convert.to_scala_list_double(quantiles)))

--- a/python/sparktk/frame/ops/sortedk.py
+++ b/python/sparktk/frame/ops/sortedk.py
@@ -108,6 +108,8 @@ def sorted_k(self, k, column_names_and_ascending, reduce_tree_depth = 2):
         [4]  Drama      1957  12 Angry Men
 
     """
-    return self._tc.frame.create(self._scala.sortedK(k,
-                                 self._tc.jutils.convert.to_scala_list_string_bool_tuple(column_names_and_ascending),
-                                 reduce_tree_depth))
+    from sparktk.frame.frame import Frame
+    return Frame(self._tc,
+                 self._scala.sortedK(k,
+                                     self._tc.jutils.convert.to_scala_list_string_bool_tuple(column_names_and_ascending),
+                                     reduce_tree_depth))

--- a/python/sparktk/frame/ops/timeseries_from_observations.py
+++ b/python/sparktk/frame/ops/timeseries_from_observations.py
@@ -73,6 +73,6 @@ def timeseries_from_observations(self, date_time_index, timestamp_column, key_co
         raise TypeError("date_time_index should be a list of date/times")
 
     scala_date_list = self._tc.jutils.convert.to_scala_date_time_list(date_time_index)
-
-    return self._tc.frame.create(
-        self._scala.timeSeriesFromObseravations(scala_date_list, timestamp_column, key_column, value_column))
+    from sparktk.frame.frame import Frame
+    return Frame(self._tc,
+                 self._scala.timeSeriesFromObseravations(scala_date_list, timestamp_column, key_column, value_column))

--- a/python/sparktk/frame/ops/timeseries_slice.py
+++ b/python/sparktk/frame/ops/timeseries_slice.py
@@ -66,7 +66,8 @@ def timeseries_slice(self, date_time_index, start, end):
     if not isinstance(end, basestring):
         raise TypeError("end date/time should be a string in the ISO 8601 format")
 
-    return self._tc.frame.create(
-        self._scala.timeSeriesSlice(self._tc.jutils.convert.to_scala_date_time_list(date_time_index),
-                                    self._tc.jutils.convert.to_scala_date_time(start),
-                                    self._tc.jutils.convert.to_scala_date_time(end)))
+    from sparktk.frame.frame import Frame
+    return Frame(self._tc,
+                 self._scala.timeSeriesSlice(self._tc.jutils.convert.to_scala_date_time_list(date_time_index),
+                                             self._tc.jutils.convert.to_scala_date_time(start),
+                                             self._tc.jutils.convert.to_scala_date_time(end)))

--- a/python/sparktk/frame/ops/topk.py
+++ b/python/sparktk/frame/ops/topk.py
@@ -83,4 +83,5 @@ def top_k(self, column_name, k, weight_column=None):
         [1]  Clackamas     3.0
 
     """
-    return self._tc.frame.create(self._scala.topK(column_name, k, self._tc.jutils.convert.to_scala_option(weight_column)))
+    from sparktk.frame.frame import Frame
+    return Frame(self._tc, self._scala.topK(column_name, k, self._tc.jutils.convert.to_scala_option(weight_column)))

--- a/python/sparktk/models/timeseries/arx.py
+++ b/python/sparktk/models/timeseries/arx.py
@@ -247,7 +247,8 @@ class ArxModel(PropertiesObject):
         elif len(x_columns) <= 0:
             raise ValueError("'x_columns' should not be empty.")
         scala_x_columns = self._tc.jutils.convert.to_scala_vector_string(x_columns)
-        return self._tc.frame.create(self._scala.predict(frame._scala, ts_column, scala_x_columns))
+        from sparktk.frame.frame import Frame
+        return Frame(self._tc, self._scala.predict(frame._scala, ts_column, scala_x_columns))
 
     def save(self, path):
         """


### PR DESCRIPTION
For frame operation code that we using frame.create() with a scala frame, it was changed to instead call the Frame constructor directly.  If a user wants to create a frame from a frame, they should instead use frame.copy().
