### PR TITLE
uses a full path for the installation procedure

### DIFF
--- a/regression-tests/automation/install_source.sh
+++ b/regression-tests/automation/install_source.sh
@@ -10,7 +10,7 @@ echo "Uninstalling spark_tk"
 sudo pip2.7 uninstall -y sparktk
 
 echo "installing spark_tk"
-sudo pip2.7 install $MAINDIR/python/dist/*.gz
+sudo pip2.7 install $MAINDIR/python/dist/sparktk-1.0.dev$BUILD_NUMBER.tar.gz 
 
 echo "linking pyspark"
 sudo ln -fs /opt/cloudera/parcels/CDH/lib/spark/python/pyspark /usr/lib/python2.7/site-packages/

--- a/regression-tests/automation/install_source.sh
+++ b/regression-tests/automation/install_source.sh
@@ -10,6 +10,7 @@ echo "Uninstalling spark_tk"
 sudo pip2.7 uninstall -y sparktk
 
 echo "installing spark_tk"
+ls $MAINDIR/python/dist
 sudo pip2.7 install $MAINDIR/python/dist/sparktk-1.0.dev$BUILD_NUMBER.tar.gz 
 
 echo "linking pyspark"


### PR DESCRIPTION
This hopefully addresses an issue concerning the correct python spark-tk package getting selected by pip for installation.
