### PR TITLE
Remove duplicate jar paths for pyspark init --jar arg

### DIFF
--- a/integration-tests/tests/test_sparkconf.py
+++ b/integration-tests/tests/test_sparkconf.py
@@ -1,0 +1,26 @@
+from setup import tc, rm, get_sandbox_path
+from sparktk import sparkconf
+import os
+
+def test_get_jars_filters_duplictes(tc):
+    """
+    Tests that get_jars_and_classpaths() does not return duplicate jars.  Calls the function with duplicate
+    directories, so that in the function, it should get duplicate jars, but those should be filtered out
+    before the jars are returned.
+    """
+    sparktk_dirs = sparkconf.get_sparktk_dirs()
+    duplicate_dirs = sparktk_dirs + sparktk_dirs
+    # call get_jars_and_classpaths with duplicate directories so that we can be sure to have
+    # duplicate jars that should get filtered out.
+    paths = sparkconf.get_jars_and_classpaths(duplicate_dirs)
+
+    # expect to get back jars and class paths
+    assert(len(paths) == 2)
+
+    # get jar names from the paths
+    jars = str.split(paths[0], ",")
+    jar_names = [os.path.basename(j) for j in jars]
+
+    # jar names should all be unique
+    assert(len(set(jar_names)) == len(jar_names))
+

--- a/python/sparktk/sparkconf.py
+++ b/python/sparktk/sparkconf.py
@@ -44,7 +44,19 @@ def get_jars_and_classpaths(dirs):
     :return: (jars, classpath)
     """
     classpath = ':'.join(["%s/*" % d for d in dirs])
-    jar_files = [os.path.join(d, f) for d in dirs for f in os.listdir(d) if f.endswith('.jar')]
+
+    # list of tuples with the directory and jar file
+    dir_jar = [(d, f) for d in dirs for f in os.listdir(d) if f.endswith('.jar')]
+
+    # Get jar file list without any duplicate jars (use the one from the first directory it's found in).  If
+    # we don't remove duplicates, we get warnings about the jar already having been registered.
+    distinct_jars = set()
+    jar_files = []
+    for dir, jar in dir_jar:
+        if jar not in distinct_jars:
+            jar_files.append(os.path.join(dir, jar))
+            distinct_jars.add(jar)
+
     jars = ','.join(jar_files)
     return jars, classpath
 

--- a/sparktk-core/src/test/scala/org/trustedanalytics/sparktk/models/timeseries/arimax/ArimaxModelTest.scala
+++ b/sparktk-core/src/test/scala/org/trustedanalytics/sparktk/models/timeseries/arimax/ArimaxModelTest.scala
@@ -24,13 +24,13 @@ import org.trustedanalytics.sparktk.testutils.TestingSparkContextWordSpec
 
 class ArimaxModelTest extends TestingSparkContextWordSpec with Matchers {
   /**
-    * Air quality data from:
-    *
-    * https://archive.ics.uci.edu/ml/datasets/Air+Quality.
-    *
-    * Lichman, M. (2013). UCI Machine Learning Repository [http://archive.ics.uci.edu/ml].
-    * Irvine, CA: University of California, School of Information and Computer Science.
-    */
+   * Air quality data from:
+   *
+   * https://archive.ics.uci.edu/ml/datasets/Air+Quality.
+   *
+   * Lichman, M. (2013). UCI Machine Learning Repository [http://archive.ics.uci.edu/ml].
+   * Irvine, CA: University of California, School of Information and Computer Science.
+   */
   val rows: Array[Row] = Array(
     new GenericRow(Array[Any]("10/03/2004", "18.00.00", 2.6, 1360, 150, 11.9, 1046, 166, 1056, 113, 1692, 1268, 13.6, 48.9, 0.7578)),
     new GenericRow(Array[Any]("10/03/2004", "19.00.00", 2, 1292, 112, 9.4, 955, 103, 1174, 92, 1559, 972, 13.3, 47.7, 0.7255)),


### PR DESCRIPTION
If the pyspark --jars arg has multiple paths to the same jar, it prints out some warnings during the TkContext initialization. I see this when including daaltk as an other_lib, since there are dependencies that both spark-tk and daal-tk have (for example: mahout-math, log4j, sparktk-core). In order to reduce the junk that gets printed out during TkContext init, I added some code to remove duplicate jars.
