### PR TITLE
Update to spark-ts 0.3.5 to get Augmented Dickey-Fuller test fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -772,7 +772,7 @@
         <dependency>
           <groupId>com.cloudera.sparkts</groupId>
           <artifactId>sparkts</artifactId>
-          <version>0.3.4</version>
+          <version>0.3.5</version>
           <exclusions>
             <exclusion>
               <artifactId>breeze_${tap.scala.short.version}</artifactId>

--- a/python/sparktk/frame/ops/timeseries_augmented_dickey_fuller_test.py
+++ b/python/sparktk/frame/ops/timeseries_augmented_dickey_fuller_test.py
@@ -67,8 +67,9 @@ def timeseries_augmented_dickey_fuller_test(self, ts_column, max_lag, regression
     values and the max_lag.  The function returns an object that has properties for the p-value and test statistic.
 
         >>> frame.timeseries_augmented_dickey_fuller_test("timeseries_values", 0)
-        p_value   = 3.3005431721e-11
-        test_stat = -7.54504405591
+        p_value   = 0.0
+        test_stat = -9.93422373369
+
 
     """
 


### PR DESCRIPTION
Update spark-timeseries version to 0.3.5 (which has the ADF fix) and dickey-fuller doc test to reflect the fixed values.
