### PR TITLE
Enables the graph triangle count regression test

### DIFF
--- a/regression-tests/sparktkregtests/testcases/graph/graph_triangle_count_test.py
+++ b/regression-tests/sparktkregtests/testcases/graph/graph_triangle_count_test.py
@@ -26,7 +26,6 @@ from sparktkregtests.lib import sparktk_test
 
 class TriangleCount(sparktk_test.SparkTKTestCase):
 
-    @unittest.skip("DPNG-11961")
     def test_triangle_counts(self):
         """Build frames and graphs to exercise"""
         super(TriangleCount, self).setUp()


### PR DESCRIPTION
The graph triangle count test was failing due to unknown issues, disabled for the 0.7.3 release.