### PR TITLE
Moves relative path sourcing from root to be consistent in the regression tests

### DIFF
--- a/regression-tests/sparktkregtests/lib/config.py
+++ b/regression-tests/sparktkregtests/lib/config.py
@@ -19,8 +19,8 @@
 import os
 
 
-qa_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
-dataset_directory = os.path.join(qa_root, "datasets")
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__)))))
+dataset_directory = os.path.join(root, "regression-tests", "datasets")
 hdfs_namenode = os.getenv("CDH_MASTER", "localhost")
 user = os.getenv("USER", "hadoop")
 run_mode = True if os.getenv("RUN_MODE", "yarn_client") == "yarn_client" else False

--- a/regression-tests/sparktkregtests/lib/scoring_utils.py
+++ b/regression-tests/sparktkregtests/lib/scoring_utils.py
@@ -35,8 +35,7 @@ class scorer(object):
         # set port
         port_config = SafeConfigParser()
         filepath = os.path.abspath(os.path.join(
-            config.root, "regression-tests",
-            "sparktkregtests", "lib", "port.ini"))
+            config.root, "regression-tests", "sparktkregtests", "lib", "port.ini"))
         port_config.read(filepath)
         self.port = port_config.get('port', port_id)
         self.scoring_process = None

--- a/regression-tests/sparktkregtests/lib/scoring_utils.py
+++ b/regression-tests/sparktkregtests/lib/scoring_utils.py
@@ -35,8 +35,8 @@ class scorer(object):
         # set port
         config = SafeConfigParser()
         filepath = os.path.abspath(os.path.join(
-            os.path.dirname(os.path.realpath(__file__)),
-            "port.ini"))
+            config.root, "regression-tests",
+            "sparktkregtests", "lib", "port.ini"))
         config.read(filepath)
         self.port = config.get('port', port_id)
         self.scoring_process = None
@@ -44,10 +44,7 @@ class scorer(object):
     def __enter__(self):
         """Activate the Server"""
         # change current working directory to point at scoring_engine dir
-        run_path = os.path.abspath(os.path.join(
-            os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
-                os.path.realpath(__file__))))),
-            "scoring", "scoring_engine"))
+        run_path = os.path.abspath(os.path.join(config.root, "scoring", "scoring_engine"))
 
         # keep track of cwd for future
         test_dir = os.getcwd()

--- a/regression-tests/sparktkregtests/lib/scoring_utils.py
+++ b/regression-tests/sparktkregtests/lib/scoring_utils.py
@@ -33,12 +33,12 @@ class scorer(object):
         self.name = host.split('.')[0]
         self.host = host
         # set port
-        config = SafeConfigParser()
+        port_config = SafeConfigParser()
         filepath = os.path.abspath(os.path.join(
             config.root, "regression-tests",
             "sparktkregtests", "lib", "port.ini"))
-        config.read(filepath)
-        self.port = config.get('port', port_id)
+        port_config.read(filepath)
+        self.port = port_config.get('port', port_id)
         self.scoring_process = None
 
     def __enter__(self):

--- a/regression-tests/sparktkregtests/lib/sparktk_test.py
+++ b/regression-tests/sparktkregtests/lib/sparktk_test.py
@@ -26,7 +26,7 @@ import sparktk as stk
 
 import config
 from threading import Lock
-udf_lib_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),"udftestlib")
+udf_lib_path = os.path.join(config.root, "regression-tests", "sparktkregtests", "lib" ,"udftestlib")
 udf_files = [os.path.join(udf_lib_path, f) for f in os.listdir(udf_lib_path)]
 
 lock = Lock()


### PR DESCRIPTION
The root directory for the regression tests was set to be the regression-test folder under the top level directory. It is now the top level directory, which makes more sense as the regression automation has evolved.

Several files were also switched to source from this path rather than recalculating the root directory themselves (increasing consistency).