### PR TITLE
Mark isolated vertices as having degree 0

### DIFF
--- a/python/sparktk/graph/ops/weighted_degrees.py
+++ b/python/sparktk/graph/ops/weighted_degrees.py
@@ -58,24 +58,23 @@ def weighted_degrees(self, edge_weight, degree_option='undirected', default_weig
 
         >>> result = graph.weighted_degrees(edge_weight="weight", degree_option="out")
         >>> result.inspect() 
-        [#]  id  degree
-        ===============
-        [0]   1       4
-        [1]   2       1
-        [2]   3       0
-        [3]   4       1
-        [4]   5       0
-
+        [#]  id  label  degree
+        ======================
+        [0]   1    1.0       4
+        [1]   2    1.0       1
+        [2]   3    5.0       0
+        [3]   4    5.0       1
+        [4]   5    5.0       0
 
         >>> result = graph.weighted_degrees(edge_weight="weight", degree_option="in")
         >>> result.inspect()
-        [#]  id  degree
-        ===============
-        [0]   1       0
-        [1]   2       2
-        [2]   3       2
-        [3]   4       1
-        [4]   5       1
+        [#]  id  label  degree
+        ======================
+        [0]   1    1.0       0
+        [1]   2    1.0       2
+        [2]   3    5.0       2
+        [3]   4    5.0       1
+        [4]   5    5.0       1
 
     """
     from sparktk.frame.frame import Frame

--- a/regression-tests/sparktkregtests/testcases/graph/graph_degree_test.py
+++ b/regression-tests/sparktkregtests/testcases/graph/graph_degree_test.py
@@ -45,6 +45,38 @@ class WeightedDegreeTest(sparktk_test.SparkTKTestCase):
 
         self.graph = self.context.graph.create(self.vertices, self.frame)
 
+    def test_degree_isolated(self):
+        """Test degree with an isolated vertex"""
+        vertex_frame = self.context.frame.create(
+                          [[1],
+                           [2],
+                           [3],
+                           [4],
+                           [5]],
+                          [("id", int)])
+        edge_frame = self.context.frame.create(
+                          [[2, 3],
+                           [2, 1],
+                           [2, 5]],
+                          [("src", int),
+                           ("dst", int)])
+
+        graph = self.context.graph.create(vertex_frame, edge_frame)
+
+        degree = graph.degrees()
+
+        known_vals = {1: 1,
+                      2: 3,
+                      3: 1,
+                      4: 0,
+                      5: 1}
+        degree_pandas = degree.to_pandas(degree.count())
+
+        for _, row in degree_pandas.iterrows():
+            self.assertAlmostEqual(known_vals[row["id"]], row['degree'])
+            self.assertAlmostEqual(known_vals[row["id"]], row['degree'])
+            self.assertAlmostEqual(known_vals[row["id"]], row['degree'])
+
     def test_degree_out(self):
         """Test degree count for out edges"""
         graph_result = self.graph.degrees(degree_option="out")

--- a/regression-tests/sparktkregtests/testcases/graph/graph_weight_degree_test.py
+++ b/regression-tests/sparktkregtests/testcases/graph/graph_weight_degree_test.py
@@ -47,6 +47,39 @@ class WeightedDegreeTest(sparktk_test.SparkTKTestCase):
 
         self.graph = self.context.graph.create(self.vertices, self.frame)
 
+    def test_weighted_degree_isolated(self):
+        """Test weighted degree with an isolated vertex"""
+        vertex_frame = self.context.frame.create(
+                          [[1],
+                           [2],
+                           [3],
+                           [4],
+                           [5]],
+                          [("id", int)])
+        edge_frame = self.context.frame.create(
+                          [[2, 3, 1],
+                           [2, 1, 1],
+                           [2, 5, 2]],
+                          [("src", int),
+                           ("dst", int),
+                           ("weight", int)])
+
+        graph = self.context.graph.create(vertex_frame, edge_frame)
+
+        degree = graph.weighted_degrees("weight")
+
+        known_vals = {1: 1,
+                      2: 4,
+                      3: 1,
+                      4: 0,
+                      5: 2}
+        degree_pandas = degree.to_pandas(degree.count())
+
+        for _, row in degree_pandas.iterrows():
+            self.assertAlmostEqual(known_vals[row["id"]], row['degree'])
+            self.assertAlmostEqual(known_vals[row["id"]], row['degree'])
+            self.assertAlmostEqual(known_vals[row["id"]], row['degree'])
+
     def test_annotate_weight_degree_out(self):
         """Test degree count weighted on out edges"""
         degree_weighted = self.graph.weighted_degrees("value", "out")

--- a/sparktk-core/src/main/scala/org/trustedanalytics/sparktk/graph/internal/ops/Degree.scala
+++ b/sparktk-core/src/main/scala/org/trustedanalytics/sparktk/graph/internal/ops/Degree.scala
@@ -52,6 +52,6 @@ case class Degree(degreeOption: String) extends GraphSummarization[Frame] {
     }
     val degrees = state.graphFrame.aggregateMessages.sendToDst(dstMsg).sendToSrc(srcMsg).agg(sum(AggregateMessages.msg).as(outputName))
 
-    new Frame(state.graphFrame.vertices.join(degrees, col(outputName), "left").na.fill(0.0, Array(outputName)))
+    new Frame(state.graphFrame.vertices.join(degrees, state.graphFrame.vertices(GraphFrame.ID).equalTo(degrees(GraphFrame.ID)), "left").drop(degrees(GraphFrame.ID)).na.fill(0.0, Array(outputName)))
   }
 }

--- a/sparktk-core/src/main/scala/org/trustedanalytics/sparktk/graph/internal/ops/Degree.scala
+++ b/sparktk-core/src/main/scala/org/trustedanalytics/sparktk/graph/internal/ops/Degree.scala
@@ -51,6 +51,7 @@ case class Degree(degreeOption: String) extends GraphSummarization[Frame] {
       case "undirected" => (lit(1), lit(1))
     }
     val degrees = state.graphFrame.aggregateMessages.sendToDst(dstMsg).sendToSrc(srcMsg).agg(sum(AggregateMessages.msg).as(outputName))
-    new Frame(degrees)
+
+    new Frame(state.graphFrame.vertices.join(degrees, col(outputName), "left").na.fill(0.0, Array(outputName)))
   }
 }

--- a/sparktk-core/src/main/scala/org/trustedanalytics/sparktk/graph/internal/ops/WeightedDegree.scala
+++ b/sparktk-core/src/main/scala/org/trustedanalytics/sparktk/graph/internal/ops/WeightedDegree.scala
@@ -59,6 +59,6 @@ case class WeightedDegree(edgeWeight: String, degreeOption: String, defaultWeigh
       case "undirected" => (AggregateMessages.edge(edgeWeight), AggregateMessages.edge(edgeWeight))
     }
     val weightedDegrees = graphFrame.aggregateMessages.sendToDst(dstMsg).sendToSrc(srcMsg).agg(sum(AggregateMessages.msg).as(outputName))
-    new Frame(weightedDegrees)
+    new Frame(state.graphFrame.vertices.join(weightedDegrees, state.graphFrame.vertices(GraphFrame.ID).equalTo(weightedDegrees(GraphFrame.ID)), "left").drop(weightedDegrees(GraphFrame.ID)).na.fill(0.0, Array(outputName)))
   }
 }


### PR DESCRIPTION
Improves degree and weighted degree to mark isolated vertices as having degree 0. Formerly these vertices were simply dropped after these operations. Increases regression tests to capture this improvement.