### PR TITLE
stopping spark context once model has been read

### DIFF
--- a/sparktk-core/src/main/scala/org/trustedanalytics/sparktk/models/SparkTkModelAdapter.scala
+++ b/sparktk-core/src/main/scala/org/trustedanalytics/sparktk/models/SparkTkModelAdapter.scala
@@ -47,11 +47,14 @@ class SparkTkModelAdapter() extends ModelReader {
    * @return loads and returns the sparktk model
    */
   override def read(modelZipStreamInput: ZipInputStream, classLoader: URLClassLoader, jsonMap: Map[String, String]): Model = {
-    logger.info("Sparktk model Adapter called")
+    logger.info("Sparktk model Adapter called.")
     val sparktkObject = classLoader.loadClass(jsonMap(MODEL_NAME) + "$").getField("MODULE$").get(null).asInstanceOf[TkSaveableObject]
     Thread.currentThread().setContextClassLoader(classLoader)
     val tc = createSimpleContext(modelZipStreamInput)
-    sparktkObject.load(tc, getModelPath(modelZipStreamInput)).asInstanceOf[Model]
+    val model = sparktkObject.load(tc, getModelPath(modelZipStreamInput)).asInstanceOf[Model]
+    tc.sc.stop()
+    logger.info("Spark context is stopped after reading model.")
+    model
   }
 
   /**


### PR DESCRIPTION
This change is as a part of DPNG-12495, where revised model api was throwing error due to multiple spark context were getting created.